### PR TITLE
Add Doclaynet to dla datasets and deedoctection to pdf processing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Documents are a core part of many businesses in many fields such as law, finance
 1. [pdf-text-extraction-benchmark](https://github.com/ckorzen/pdf-text-extraction-benchmark) ![](https://img.shields.io/github/stars/ckorzen/pdf-text-extraction-benchmark.svg?style=social) - PDF tools benchmark
 1. [Born digital pdf scanner](https://github.com/applicaai/digital-born-pdf-scanner) ![](https://img.shields.io/github/stars/applicaai/digital-born-pdf-scanner.svg?style=social) - checking if pdf is born-digital
 1. [OpenContracts](https://github.com/JSv4/OpenContracts) ![](https://img.shields.io/github/stars/JSv4/OpenContracts?style=social) Apache2-licensed, PDF annotating platform for visually-rich documents that preserves the original layout and exports x,y positional data for tokens as well as span starts and stops. Based on PAWLs, but with a Python-based backend and readily deployable on your local machine, company intranet or the web via Docker Compose.
-
+1. [deepdoctection](https://github.com/deepdoctection/deepdoctection) ![](https://img.shields.io/github/stars/deepdoctection/deepdoctection?style=social) **deep**doctection is a Python library that orchestrates document extraction and document layout analysis tasks for images and pdf documents using deep learning models. It does not implement models but enables you to build pipelines using highly acknowledged libraries for object detection, OCR and selected NLP tasks and provides an integrated framework for fine-tuning, evaluating and running models. 
 
 ## Conferences, workshops
 

--- a/topics/dla/README.md
+++ b/topics/dla/README.md
@@ -56,6 +56,12 @@ Document Layout Analysis is a Computer Vision approach to the problem of detecti
 
 ## Datasets 
 
+* [DocLayNet: A Large Human-Annotated Dataset for Document-Layout Analysis](https://arxiv.org/pdf/2206.01062.pdf), \[[code/data](https://github.com/DS4SD/DocLayNet) ![](https://img.shields.io/github/stars/DS4SD/DocLayNet.svg?style=social)\]
+    <details>
+    <summary> Birgit Pfitzmann, Christoph Auer, Michele Dolfi, Ahmed S. Nassar and Peter Staar <em>Proceedings of the 28th ACM SIGKDD Conference on Knowledge Discovery and Data Mining</em></summary>
+        In this paper, we present DocLayNet, a new, publicly available, document-layout annotation dataset in COCO format. It contains 80863 manually annotated pages from diverse data sources to represent a wide variability in layouts. For each PDF page, the layout annotations provide labelled bounding-boxes with a choice of 11 distinct classes. DocLayNet also provides a subset of double- and triple-annotated pages to determine the inter-annotator agreement. 
+    </details>
+
 * [DocBank: A Benchmark Dataset for Document Layout Analysis](https://arxiv.org/pdf/2006.01038.pdf), \[[code/data](https://github.com/doc-analysis/DocBank) ![](https://img.shields.io/github/stars/doc-analysis/DocBank.svg?style=social)\]
     <details>
     <summary> Minghao Li et al. <em>COLING</em> 2020 </summary>


### PR DESCRIPTION
This PR adds:

+ DocLayNet, a new, publicly available, document-layout annotation dataset in COCO format to DLA  datasets. It contains 80863 manually annotated pages.
+ deepdoctection to PDF processing tools